### PR TITLE
[MISC]: Update dependencies, update deprecated code and fix clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,40 +1,51 @@
 [package]
 name = "alevin-fry"
 version = "0.5.0"
-authors = ["Avi Srivastava <avi.srivastava@nyu.edu>", "Hirak Sarkar <hirak_sarkar@hms.harvard.edu>", "Dongze He <dhe17@umd.edu>", "Mohsen Zakeri <mzakeri@cs.umd.edu>", "Rob Patro <rob@cs.umd.edu>"]
-edition = "2018"
+authors = [
+  "Avi Srivastava <avi.srivastava@nyu.edu>",
+  "Hirak Sarkar <hirak_sarkar@hms.harvard.edu>",
+  "Dongze He <dhe17@umd.edu>",
+  "Mohsen Zakeri <mzakeri@cs.umd.edu>",
+  "Rob Patro <rob@cs.umd.edu>",
+]
+edition = "2021"
 description = "A suite of tools for the rapid, accurate and memory-frugal processing single-cell and single-nucleus sequencing data."
 license-file = "LICENSE"
-readme= "README.md"
+readme = "README.md"
 repository = "https://github.com/COMBINE-lab/alevin-fry"
 homepage = "https://github.com/COMBINE-lab/alevin-fry"
 documentation = "https://alevin-fry.readthedocs.io/en/latest/"
 include = [
-    "/libradicl/src/*.rs",
-    "/src/*.rs",
-    "/Cargo.toml",
-    "/README.md",
-    "/LICENSE",
-    "/CONTRIBUTING.md",
-    "/CODE_OF_CONDUCT.md"
+  "/libradicl/src/*.rs",
+  "/src/*.rs",
+  "/Cargo.toml",
+  "/README.md",
+  "/LICENSE",
+  "/CONTRIBUTING.md",
+  "/CODE_OF_CONDUCT.md",
 ]
-keywords = ["single-cell", "preprocessing", 
-	    "RNA-seq", "single-nucleus", "RNA-velocity"]
+keywords = [
+  "single-cell",
+  "preprocessing",
+  "RNA-seq",
+  "single-nucleus",
+  "RNA-velocity",
+]
 categories = ["command-line-utilities", "science"]
 
 [workspace]
 
-[dependencies]	
+[dependencies]
 # for release
-libradicl = "0.4.4" 
+libradicl = "0.4.4"
 # for local development
 # libradicl = { path = "libradicl", version = "0.4.4" }
 arrayvec = "0.7.2"
 ahash = "0.7.6"
 bincode = "1.3.3"
 bstr = "0.2.17"
-crossbeam-channel = "0.5.2"
-crossbeam-queue = "0.3.4"
+crossbeam-channel = "0.5.4"
+crossbeam-queue = "0.3.5"
 indicatif = "0.16.2"
 needletail = "0.4.1"
 petgraph = "0.6.0"
@@ -44,30 +55,33 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 sprs = "0.11.0"
 slog = "2.7.0"
-slog-term = "2.8.1"
+slog-term = "2.9.0"
 slog-async = "2.7.0"
 smallvec = "1.8.0"
-snap = "1"
+snap = "1.0.5"
 rand = "0.8.5"
 chrono = "0.4.19"
 csv = "1.1.6"
 mimalloc = { version = "0.1.28", default-features = false }
 num-format = "0.4.0"
-num_cpus = "1.13.0"
+num_cpus = "1.13.1"
 bio-types = "0.12.1"
-itertools = "0.10.1"
+itertools = "0.10.3"
 thiserror = "1.0.30"
 quickersort = "3.0.1"
-statrs = "0.15.0" 
-rust-htslib = { version = "0.38.2", default-features = false, features = ["bzip2", "lzma"] }
+statrs = "0.15.0"
+rust-htslib = { version = "0.38.2", default-features = false, features = [
+  "bzip2",
+  "lzma",
+] }
 sce = { git = "https://github.com/parazodiac/SingleCellExperiment", version = "0.1.1" }
 
 [dependencies.clap]
-version = "3.0.14"
+version = "3.1.6"
 features = ["wrap_help", "cargo"]
 
 [profile.release]
 #debug = true
-lto="thin"
+lto = "thin"
 #codegen-units=1
-opt-level=3
+opt-level = 3

--- a/src/cellfilter.rs
+++ b/src/cellfilter.rs
@@ -231,16 +231,15 @@ fn process_unfiltered(
     std::fs::create_dir_all(&parent).unwrap();
 
     // the smallest number of reads we'll allow per barcode
-    let min_freq;
-    match filter_meth {
+    let min_freq = match filter_meth {
         CellFilterMethod::UnfilteredExternalList(_, min_reads) => {
             info!(log, "minimum num reads for barcode pass = {}", *min_reads);
-            min_freq = *min_reads as u64;
+            *min_reads as u64
         }
         _ => {
             unimplemented!();
         }
-    }
+    };
 
     // the set of barcodes we'll keep
     let mut kept_bc = Vec::<u64>::new();

--- a/src/collate.rs
+++ b/src/collate.rs
@@ -267,11 +267,8 @@ pub fn collate_with_temp(
 
     // velo_mode
     let velo_mode = mdata["velo_mode"].as_bool().unwrap();
-    let expected_ori: Strand;
-    match get_orientation(&mdata) {
-        Ok(o) => {
-            expected_ori = o;
-        }
+    let expected_ori: Strand = match get_orientation(&mdata) {
+        Ok(o) => o,
         Err(e) => {
             crit!(
                 log,
@@ -281,7 +278,7 @@ pub fn collate_with_temp(
             );
             return Err(e.into());
         }
-    }
+    };
 
     let filter_type = get_filter_type(&mdata, log);
     let most_ambig_record = get_most_ambiguous_record(&mdata, log);

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -198,19 +198,17 @@ pub fn bam2rad(input_file: String, rad_file: String, num_threads: u32, log: &slo
             .expect("coudn't write to output file");
 
         // read-level
-        let bc_string_in;
-        if let Ok(Aux::String(bcs)) = rec.aux(b"CR") {
-            bc_string_in = bcs.to_string();
+        let bc_string_in: String = if let Ok(Aux::String(bcs)) = rec.aux(b"CR") {
+            bcs.to_string()
         } else {
             panic!("Input record missing CR tag!");
-        }
+        };
 
-        let umi_string_in;
-        if let Ok(Aux::String(umis)) = rec.aux(b"UR") {
-            umi_string_in = umis.to_string();
+        let umi_string_in: String = if let Ok(Aux::String(umis)) = rec.aux(b"UR") {
+            umis.to_string()
         } else {
             panic!("Input record missing UR tag!");
-        }
+        };
 
         let bclen = bc_string_in.len() as u16;
         let umilen = umi_string_in.len() as u16;
@@ -382,19 +380,17 @@ pub fn bam2rad(input_file: String, rad_file: String, num_threads: u32, log: &slo
 
         // if this is a new read update the old variables
         {
-            let bc_string_in;
-            if let Ok(Aux::String(bcs)) = rec.aux(b"CR") {
-                bc_string_in = bcs.to_string();
+            let bc_string_in: String = if let Ok(Aux::String(bcs)) = rec.aux(b"CR") {
+                bcs.to_string()
             } else {
                 panic!("Input record missing CR tag!");
-            }
+            };
 
-            let umi_string_in;
-            if let Ok(Aux::String(umis)) = rec.aux(b"UR") {
-                umi_string_in = umis.to_string();
+            let umi_string_in: String = if let Ok(Aux::String(umis)) = rec.aux(b"UR") {
+                umis.to_string()
             } else {
                 panic!("Input record missing UR tag!");
-            }
+            };
 
             let bc_string = bc_string_in.replacen('N', "A", 1);
             let umi_string = umi_string_in.replacen('N', "A", 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ extern crate slog;
 extern crate slog_term;
 
 use bio_types::strand::Strand;
-use clap::{arg, crate_authors, crate_version, App, AppSettings, ArgSettings};
+use clap::{arg, crate_authors, crate_version, Command};
 use csv::Error as CSVError;
 use csv::ErrorKind;
 use itertools::Itertools;
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // capture the entire command line as a string
     let cmdline = std::env::args().join(" ");
 
-    let convert_app = App::new("convert")
+    let convert_app = Command::new("convert")
         .about("Convert a BAM file to a RAD file")
         .version(version)
         .author(crate_authors)
@@ -69,7 +69,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .arg(arg!(-o --output <RADFILE> "output RAD file"));
 
-    let view_app = App::new("view")
+    let view_app = Command::new("view")
         .about("View a RAD file")
         .version(version)
         .author(crate_authors)
@@ -81,7 +81,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .arg(arg!(-o --output <RADFILE> "output plain-text-file file").required(false));
 
-    let gen_app = App::new("generate-permit-list")
+    let gen_app = Command::new("generate-permit-list")
         .about("Generate a permit list of barcodes from a RAD file")
         .version(version)
         .author(crate_authors)
@@ -114,7 +114,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .required(true));
     //.arg(Arg::from("-v --velocity-mode 'flag for velocity mode'").takes_value(false).required(false));
 
-    let collate_app = App::new("collate")
+    let collate_app = Command::new("collate")
     .about("Collate a RAD file by corrected cell barcode")
     .version(version)
     .author(crate_authors)
@@ -127,7 +127,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     //.arg(arg!(-e --expected-ori=[expected-ori] 'the expected orientation of alignments'")
     //     .default_value(fw"));
 
-    let quant_app = App::new("quant")
+    let quant_app = Command::new("quant")
     .about("Quantify expression from a collated RAD file")
     .version(version)
     .author(crate_authors)
@@ -147,10 +147,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .arg(arg!(--"sa-model" "preferred model of splicing ambiguity")
         .possible_values(&["prefer-ambig", "winner-take-all"])
         .default_value("winner-take-all")
-        .setting(ArgSettings::Hidden))
-    .arg(arg!(--"small-thresh" <SMALLTHRESH> "cells with fewer than these many reads will be resolved using a custom approach").default_value("10").setting(ArgSettings::Hidden));
+        .hide(true)
+    )
+    .arg(arg!(--"small-thresh" <SMALLTHRESH> "cells with fewer than these many reads will be resolved using a custom approach").default_value("10").hide(true));
 
-    let infer_app = App::new("infer")
+    let infer_app = Command::new("infer")
     .about("Perform inference on equivalence class count data")
     .version(version)
     .author(crate_authors)
@@ -163,8 +164,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .arg(arg!(--"quant-subset" <SFILE> "file containing list of barcodes to quantify, those not in this list will be ignored").required(false))
     .arg(arg!(--"use-mtx" "flag for writing output matrix in matrix market instead of EDS").takes_value(false).required(false));
 
-    let opts = App::new("alevin-fry")
-        .setting(AppSettings::SubcommandRequiredElseHelp)
+    let opts = Command::new("alevin-fry")
+        .subcommand_required(true)
+        .arg_required_else_help(true)
         .version(version)
         .author(crate_authors)
         .about("Process RAD files from the command line")

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -1152,7 +1152,7 @@ pub fn do_quantify<T: Read>(
                             let mut next_id = geqmap.global_eqc.len() as u64;
                             for (labels, count) in gene_eqc.iter() {
                                 let mut found = true;
-                                match geqmap.global_eqc.get(&labels.to_vec()) {
+                                match geqmap.global_eqc.get(labels) {
                                     Some(eqid) => {
                                         geqmap.cell_level_count.push((*eqid, *count));
                                     }


### PR DESCRIPTION
This PR updates the dependencies, update deprecated code, and fix clips lints. 
Also, I see that there are multiple places where `String` is used. Is this really needed, or could we change this to `&str`(which is the preferred way in rust)?
From my understanding, `String` is used when if we need to own the string data, and `&str` is used if we only need a view of a string. 
By the way, I am not a biologist  😅.