### PR TITLE
Parsimony USA  mode + other changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alevin-fry"
-version = "0.5.1"
+version = "0.6.0"
 authors = [
   "Avi Srivastava <avi.srivastava@nyu.edu>",
   "Hirak Sarkar <hirak_sarkar@hms.harvard.edu>",

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,8 @@ fn main() -> anyhow::Result<()> {
     .arg(arg!(-b --"num-bootstraps" <NUMBOOTSTRAPS> "number of bootstraps to use").default_value("0"))
     .arg(arg!(--"init-uniform" "flag for uniform sampling").requires("num-bootstraps").takes_value(false).required(false))
     .arg(arg!(--"summary-stat" "flag for storing only summary statistics").requires("num-bootstraps").takes_value(false).required(false))
-    .arg(arg!(--"use-mtx" "flag for writing output matrix in matrix market instead of EDS").takes_value(false).required(false))
+    .arg(arg!(--"use-mtx" "flag for writing output matrix in matrix market format (default)").takes_value(false).required(false))
+    .arg(arg!(--"use-eds" "flag for writing output matrix in EDS format").takes_value(false).required(false).conflicts_with("use-mtx"))
     .arg(arg!(--"quant-subset" <SFILE> "file containing list of barcodes to quantify, those not in this list will be ignored").required(false))
     .arg(arg!(-r --resolution <RESOLUTION> "the resolution strategy by which molecules will be counted")
         .possible_values(&["full", "trivial", "cr-like", "cr-like-em", "parsimony", "parsimony-em", "parsimony-gene", "parsimony-gene-em"])
@@ -158,7 +159,8 @@ fn main() -> anyhow::Result<()> {
     .arg(arg!(-t --threads <THREADS> "number of threads to use for processing").default_value(&max_num_threads))
     .arg(arg!(--usa "flag specifying that input equivalence classes were computed in USA mode").takes_value(false).required(false))
     .arg(arg!(--"quant-subset" <SFILE> "file containing list of barcodes to quantify, those not in this list will be ignored").required(false))
-    .arg(arg!(--"use-mtx" "flag for writing output matrix in matrix market instead of EDS").takes_value(false).required(false));
+    .arg(arg!(--"use-mtx" "flag for writing output matrix in matrix market format (default)").takes_value(false).required(false))
+    .arg(arg!(--"use-eds" "flag for writing output matrix in EDS format").takes_value(false).required(false).conflicts_with("use-mtx"));
 
     let opts = Command::new("alevin-fry")
         .subcommand_required(true)
@@ -343,7 +345,7 @@ fn main() -> anyhow::Result<()> {
         let init_uniform = t.is_present("init-uniform");
         let summary_stat = t.is_present("summary-stat");
         let dump_eq = t.is_present("dump-eqclasses");
-        let use_mtx = t.is_present("use-mtx");
+        let use_mtx = !t.is_present("use-eds");
         let pug_exact_umi = t.is_present("pug-exact-umi");
         let input_dir: String = t.value_of_t("input-dir").unwrap();
         let output_dir = t.value_of_t("output-dir").unwrap();
@@ -484,7 +486,7 @@ fn main() -> anyhow::Result<()> {
     // and output a target-by-cell count matrix.
     if let Some(t) = opts.subcommand_matches("infer") {
         let num_threads = t.value_of_t("threads").unwrap();
-        let use_mtx = t.is_present("use-mtx");
+        let use_mtx = !t.is_present("use-eds");
         let output_dir = t.value_of_t("output-dir").unwrap();
         let count_mat = t.value_of_t("count-mat").unwrap();
         let eq_label_file = t.value_of_t("eq-labels").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,7 +134,7 @@ fn main() -> anyhow::Result<()> {
     .arg(arg!(--"use-mtx" "flag for writing output matrix in matrix market instead of EDS").takes_value(false).required(false))
     .arg(arg!(--"quant-subset" <SFILE> "file containing list of barcodes to quantify, those not in this list will be ignored").required(false))
     .arg(arg!(-r --resolution <RESOLUTION> "the resolution strategy by which molecules will be counted")
-        .possible_values(&["full", "trivial", "cr-like", "cr-like-em", "parsimony", "parsimony-em"])
+        .possible_values(&["full", "trivial", "cr-like", "cr-like-em", "parsimony", "parsimony-em", "parsimony-gene", "parsimony-gene-em"])
         .ignore_case(true))
     .arg(arg!(--"sa-model" "preferred model of splicing ambiguity")
         .possible_values(&["prefer-ambig", "winner-take-all"])

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,6 +140,10 @@ fn main() -> anyhow::Result<()> {
         .possible_values(&["prefer-ambig", "winner-take-all"])
         .default_value("winner-take-all")
         .hide(true))
+    .arg(arg!(--"pug-exact-umi" "only consider identical UMIs as having an edge when making the PUG for parsimony resolution modes")
+        .takes_value(false)
+        .required(false)
+        .hide(true))
     .arg(arg!(--"small-thresh" <SMALLTHRESH> "cells with fewer than these many reads will be resolved using a custom approach").default_value("10")
         .hide(true));
 
@@ -340,6 +344,7 @@ fn main() -> anyhow::Result<()> {
         let summary_stat = t.is_present("summary-stat");
         let dump_eq = t.is_present("dump-eqclasses");
         let use_mtx = t.is_present("use-mtx");
+        let pug_exact_umi = t.is_present("pug-exact-umi");
         let input_dir: String = t.value_of_t("input-dir").unwrap();
         let output_dir = t.value_of_t("output-dir").unwrap();
         let tg_map = t.value_of_t("tg-map").unwrap();
@@ -436,6 +441,7 @@ fn main() -> anyhow::Result<()> {
                     dump_eq,
                     use_mtx,
                     resolution,
+                    pug_exact_umi,
                     sa_model,
                     small_thresh,
                     filter_list,

--- a/src/pugutils.rs
+++ b/src/pugutils.rs
@@ -304,9 +304,8 @@ fn collapse_vertices(
 ) -> (Vec<u32>, u32) {
     // get a new set to hold vertices
     type VertexSet = HashSet<u32, ahash::RandomState>;
-    let get_set = |cap: u32| {
-        VertexSet::with_capacity_and_hasher(cap as usize, hasher_state.clone())
-    };
+    let get_set =
+        |cap: u32| VertexSet::with_capacity_and_hasher(cap as usize, hasher_state.clone());
 
     // will hold the nodes in the largest arboresence found
     let mut largest_mcc: Vec<u32> = Vec::new();

--- a/src/pugutils.rs
+++ b/src/pugutils.rs
@@ -1036,8 +1036,7 @@ pub fn get_num_molecules(
 
                 warn!(
                     log,
-                    "\n\nfound connected component with {} vertices, \
-		     resolved into {} UMIs over {} genes with trivial resolution.\n\n",
+                    "found connected component with {} vertices, resolved into {} UMIs over {} genes with trivial resolution.",
                     comp_verts.len(),
                     numi,
                     ng

--- a/src/pugutils.rs
+++ b/src/pugutils.rs
@@ -943,6 +943,7 @@ pub fn get_num_molecules(
     tid_to_gid: &[u32],
     num_genes: usize,
     gene_eqclass_hash: &mut HashMap<Vec<u32>, u32, ahash::RandomState>,
+    usa_mode: bool,
     log: &slog::Logger,
 ) -> PugResolutionStatistics
 //,)

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -713,6 +713,16 @@ pub fn do_quantify<T: Read>(
             _ => EqMapType::TranscriptLevel,
         };
 
+        let num_gene_targets = if usa_mode {
+            (gene_name_to_id
+                .values()
+                .max()
+                .expect("gene name to id map should not be empty.")
+                + 2) as usize
+        } else {
+            num_genes as usize
+        };
+
         let num_eq_targets = match eq_map_type {
             EqMapType::TranscriptLevel => ref_count,
             EqMapType::GeneLevel => {
@@ -920,7 +930,7 @@ pub fn do_quantify<T: Read>(
                                         &g,
                                         &eq_map,
                                         &tid_to_gid,
-                                        num_genes,
+                                        num_gene_targets,
                                         &mut gene_eqc,
                                         &s,
                                         &log,

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -309,6 +309,7 @@ pub fn quantify(
     dump_eq: bool,
     use_mtx: bool,
     resolution: ResolutionStrategy,
+    pug_exact_umi: bool,
     sa_model: SplicedAmbiguityModel,
     small_thresh: usize,
     filter_list: Option<&str>,
@@ -350,6 +351,7 @@ pub fn quantify(
             dump_eq,
             use_mtx,
             resolution,
+            pug_exact_umi,
             sa_model,
             small_thresh,
             filter_list,
@@ -379,6 +381,7 @@ pub fn quantify(
             dump_eq,
             use_mtx,
             resolution,
+            pug_exact_umi,
             sa_model,
             small_thresh,
             filter_list,
@@ -404,6 +407,7 @@ pub fn do_quantify<T: Read>(
     dump_eq: bool,
     use_mtx: bool,
     resolution: ResolutionStrategy,
+    pug_exact_umi: bool,
     mut sa_model: SplicedAmbiguityModel,
     small_thresh: usize,
     filter_list: Option<&str>,
@@ -713,16 +717,6 @@ pub fn do_quantify<T: Read>(
             _ => EqMapType::TranscriptLevel,
         };
 
-        let num_gene_targets = if usa_mode {
-            (gene_name_to_id
-                .values()
-                .max()
-                .expect("gene name to id map should not be empty.")
-                + 2) as usize
-        } else {
-            num_genes as usize
-        };
-
         let num_eq_targets = match eq_map_type {
             EqMapType::TranscriptLevel => ref_count,
             EqMapType::GeneLevel => {
@@ -836,7 +830,6 @@ pub fn do_quantify<T: Read>(
                                             &tid_to_gid,
                                             num_genes,
                                             &mut gene_eqc,
-                                            usa_mode,
                                             sa_model,
                                             &log,
                                         );
@@ -847,7 +840,6 @@ pub fn do_quantify<T: Read>(
                                             &tid_to_gid,
                                             num_genes,
                                             &mut gene_eqc,
-                                            usa_mode,
                                             sa_model,
                                             &log,
                                         );
@@ -921,7 +913,7 @@ pub fn do_quantify<T: Read>(
                                         eq_map.init_from_chunk(&mut c);
                                     }
 
-                                    let g = pugutils::extract_graph(&eq_map, &log);
+                                    let g = pugutils::extract_graph(&eq_map, pug_exact_umi, &log);
                                     // for the PUG resolution algorithm, set the hasher
                                     // that will be used based on the cell barcode.
                                     let s =
@@ -930,7 +922,6 @@ pub fn do_quantify<T: Read>(
                                         &g,
                                         &eq_map,
                                         &tid_to_gid,
-                                        num_gene_targets,
                                         &mut gene_eqc,
                                         &s,
                                         &log,
@@ -1011,7 +1002,6 @@ pub fn do_quantify<T: Read>(
                                 &tid_to_gid,
                                 num_genes,
                                 &mut gene_eqc,
-                                usa_mode,
                                 sa_model,
                                 &log,
                             );

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -442,7 +442,7 @@ pub fn do_quantify<T: Read>(
     let mut gene_name_to_id: HashMap<String, u32, ahash::RandomState> =
         HashMap::with_hasher(gnhasher);
 
-    let with_unspliced;
+    let usa_mode;
     let tid_to_gid;
     // parse the tg-map; this is expected to be a 2-column
     // tsv file if we are dealing with one status of transcript
@@ -458,20 +458,24 @@ pub fn do_quantify<T: Read>(
     ) {
         Ok((v, us)) => {
             tid_to_gid = v;
-            with_unspliced = us;
-            if with_unspliced {
+            usa_mode = us;
+            if usa_mode {
                 assert_eq!(
-		     num_bootstraps, 0,
-		     "currently USA-mode (all-in-one unspliced/spliced/ambiguous) analysis cannot be used with bootstrapping."
-		 );
-                assert!(
-		     matches!(resolution,
-			      ResolutionStrategy::CellRangerLike | ResolutionStrategy::CellRangerLikeEm),
-		     "currently USA-mode (all-in-one unspliced/spliced/ambiguous) analysis can only be used with cr-like or cr-like-em resolution."
-		 );
+		           num_bootstraps, 0,
+		           "currently USA-mode (all-in-one unspliced/spliced/ambiguous) analysis cannot be used with bootstrapping."
+		        );
+
+                match  resolution  {
+                    ResolutionStrategy::Parsimony | ResolutionStrategy::Full => {
+                        info!(log,
+                        "currently USA-mode (all-in-one unspliced/spliced/ambiguous) analysis using parsimony or parsimony-em resolution is EXPERIMENTAL."
+                        );
+                    }
+                    _ => {}
+                }
             } else {
                 // the SplicedAmbiguityModel of PreferAmbiguity only makes sense when we are
-                // operating `with_unspliced`, so if the user has set that here, inform them
+                // operating `usa_mode`, so if the user has set that here, inform them
                 // it will be changed back to winner-take-all
                 match sa_model {
                     SplicedAmbiguityModel::WinnerTakeAll => {}
@@ -613,7 +617,7 @@ pub fn do_quantify<T: Read>(
     };
 
     // the length of the vector of gene counts we'll use
-    let num_rows = if with_unspliced {
+    let num_rows = if usa_mode {
         // the number of genes should be the max gene id + 1
         // over the gene ids in gene_name_to_id.  The +2 is
         // because the ids in gene_name_to_id are only for
@@ -633,7 +637,7 @@ pub fn do_quantify<T: Read>(
         num_genes
     };
 
-    let usa_offsets = if with_unspliced {
+    let usa_offsets = if usa_mode {
         Some(((num_rows / 3) as usize, (2 * num_rows / 3) as usize))
     } else {
         None
@@ -792,7 +796,7 @@ pub fn do_quantify<T: Read>(
                                             &tid_to_gid,
                                             num_genes,
                                             &mut gene_eqc,
-                                            with_unspliced,
+                                            usa_mode,
                                             sa_model,
                                             &log,
                                         );
@@ -803,7 +807,7 @@ pub fn do_quantify<T: Read>(
                                             &tid_to_gid,
                                             num_genes,
                                             &mut gene_eqc,
-                                            with_unspliced,
+                                            usa_mode,
                                             sa_model,
                                             &log,
                                         );
@@ -814,7 +818,7 @@ pub fn do_quantify<T: Read>(
 
                                     // NOTE: This configuration seems overly complicated
                                     // see if we can simplify it.
-                                    match (with_unspliced, only_unique) {
+                                    match (usa_mode, only_unique) {
                                         (true, true) => {
                                             // USA mode, only gene-unqique reads
                                             counts = afutils::extract_counts(&gene_eqc, num_rows);
@@ -865,7 +869,7 @@ pub fn do_quantify<T: Read>(
                                     mmrate.lock().unwrap()[cell_num] = ct.1;
                                     eq_map.clear();
                                 }
-                                ResolutionStrategy::Parsimony => {
+                                ResolutionStrategy::Parsimony | ResolutionStrategy::Full => {
                                     eq_map.init_from_chunk(&mut c);
                                     let g = pugutils::extract_graph(&eq_map, &log);
                                     let pug_stats = pugutils::get_num_molecules(
@@ -874,42 +878,54 @@ pub fn do_quantify<T: Read>(
                                         &tid_to_gid,
                                         num_genes,
                                         &mut gene_eqc,
+                                        usa_mode,
                                         &log,
                                     );
                                     alt_resolution = pug_stats.used_alternative_strategy; // alt_res;
-                                    counts = em_optimize(
-                                        &gene_eqc,
-                                        &mut unique_evidence,
-                                        &mut no_ambiguity,
-                                        em_init_type,
-                                        num_genes,
-                                        true, // only unqique evidence
-                                        &log,
-                                    );
                                     eq_map.clear();
-                                }
-                                ResolutionStrategy::Full => {
-                                    eq_map.init_from_chunk(&mut c);
-                                    let g = pugutils::extract_graph(&eq_map, &log);
-                                    let pug_stats = pugutils::get_num_molecules(
-                                        &g,
-                                        &eq_map,
-                                        &tid_to_gid,
-                                        num_genes,
-                                        &mut gene_eqc,
-                                        &log,
-                                    );
-                                    alt_resolution = pug_stats.used_alternative_strategy; // alt_res;
-                                    counts = em_optimize(
-                                        &gene_eqc,
-                                        &mut unique_evidence,
-                                        &mut no_ambiguity,
-                                        em_init_type,
-                                        num_genes,
-                                        false, // only unqique evidence
-                                        &log,
-                                    );
-                                    eq_map.clear();
+
+                                    let only_unique = resolution == ResolutionStrategy::Parsimony;
+
+                                    // NOTE: This configuration seems overly complicated
+                                    // see if we can simplify it.
+                                    match (usa_mode, only_unique) {
+                                        (true, true) => {
+                                            // USA mode, only gene-unqique reads
+                                            counts = afutils::extract_counts(&gene_eqc, num_rows);
+                                        }
+                                        (true, false) => {
+                                            // USA mode, use EM
+                                            afutils::extract_usa_eqmap(
+                                                &gene_eqc,
+                                                num_rows,
+                                                &mut idx_eq_list,
+                                                &mut eq_id_count,
+                                            );
+                                            counts = em_optimize_subset(
+                                                &idx_eq_list,
+                                                &eq_id_count,
+                                                &mut unique_evidence,
+                                                &mut no_ambiguity,
+                                                em_init_type,
+                                                num_rows,
+                                                only_unique,
+                                                usa_offsets,
+                                                &log,
+                                            );
+                                        }
+                                        (false, _) => {
+                                            // not USA-mode
+                                            counts = em_optimize(
+                                                &gene_eqc,
+                                                &mut unique_evidence,
+                                                &mut no_ambiguity,
+                                                em_init_type,
+                                                num_genes,
+                                                only_unique,
+                                                &log,
+                                            );
+                                        }
+                                    }
                                 }
                             }
 
@@ -940,12 +956,12 @@ pub fn do_quantify<T: Read>(
                                 &tid_to_gid,
                                 num_genes,
                                 &mut gene_eqc,
-                                with_unspliced,
+                                usa_mode,
                                 sa_model,
                                 &log,
                             );
                             // USA-mode
-                            if with_unspliced {
+                            if usa_mode {
                                 // here, just like for non-USA mode,
                                 // we substitute EM with uniform allocation in
                                 // this special case
@@ -1206,7 +1222,7 @@ pub fn do_quantify<T: Read>(
     let mut gn_writer = BufWriter::new(gn_file);
 
     // if we are not using unspliced then just write the gene names
-    if !with_unspliced {
+    if !usa_mode {
         for g in gene_names {
             gn_writer.write_all(format!("{}\n", g).as_bytes())?;
         }
@@ -1262,13 +1278,7 @@ pub fn do_quantify<T: Read>(
     );
 
     if dump_eq {
-        write_eqc_counts(
-            &eqid_map_lock,
-            num_rows,
-            with_unspliced,
-            &output_matrix_path,
-            log,
-        )?;
+        write_eqc_counts(&eqid_map_lock, num_rows, usa_mode, &output_matrix_path, log)?;
     }
 
     let meta_info = json!({
@@ -1278,7 +1288,7 @@ pub fn do_quantify<T: Read>(
     "num_quantified_cells" : num_cells,
     "num_genes" : num_rows,
     "dump_eq" : dump_eq,
-    "usa_mode" : with_unspliced,
+    "usa_mode" : usa_mode,
     "alt_resolved_cell_numbers" : *alt_res_cells.lock().unwrap(),
     "empty_resolved_cell_numbers" : *empty_resolved_cells.lock().unwrap()
     });

--- a/src/quant.rs
+++ b/src/quant.rs
@@ -68,7 +68,7 @@ pub enum ResolutionStrategy {
     Trivial,
     CellRangerLike,
     CellRangerLikeEm,
-    Full,
+    ParsimonyEm,
     Parsimony,
     ParsimonyGeneEm,
     ParsimonyGene,
@@ -88,7 +88,7 @@ impl FromStr for ResolutionStrategy {
             "trivial" => Ok(ResolutionStrategy::Trivial),
             "cr-like" => Ok(ResolutionStrategy::CellRangerLike),
             "cr-like-em" => Ok(ResolutionStrategy::CellRangerLikeEm),
-            "parsimony-em" | "full" => Ok(ResolutionStrategy::Full),
+            "parsimony-em" | "full" => Ok(ResolutionStrategy::ParsimonyEm),
             "parsimony" => Ok(ResolutionStrategy::Parsimony),
             "parsimony-gene" => Ok(ResolutionStrategy::ParsimonyGene),
             "parsimony-gene-em" => Ok(ResolutionStrategy::ParsimonyGeneEm),
@@ -475,7 +475,7 @@ pub fn do_quantify<T: Read>(
 
                 match resolution {
                     ResolutionStrategy::Parsimony
-                    | ResolutionStrategy::Full
+                    | ResolutionStrategy::ParsimonyEm
                     | ResolutionStrategy::ParsimonyGene
                     | ResolutionStrategy::ParsimonyGeneEm => {
                         info!(log,
@@ -902,7 +902,7 @@ pub fn do_quantify<T: Read>(
                                     eq_map.clear();
                                 }
                                 ResolutionStrategy::Parsimony
-                                | ResolutionStrategy::Full
+                                | ResolutionStrategy::ParsimonyEm
                                 | ResolutionStrategy::ParsimonyGene
                                 | ResolutionStrategy::ParsimonyGeneEm => {
                                     if (resolution == ResolutionStrategy::ParsimonyGene)
@@ -1017,7 +1017,7 @@ pub fn do_quantify<T: Read>(
                                         counts = afutils::extract_counts(&gene_eqc, num_rows);
                                     }
                                     ResolutionStrategy::CellRangerLikeEm
-                                    | ResolutionStrategy::Full
+                                    | ResolutionStrategy::ParsimonyEm
                                     | ResolutionStrategy::ParsimonyGeneEm => {
                                         counts =
                                             afutils::extract_counts_mm_uniform(&gene_eqc, num_rows);
@@ -1036,7 +1036,7 @@ pub fn do_quantify<T: Read>(
                                     } else {
                                         match resolution {
                                             ResolutionStrategy::CellRangerLikeEm
-                                            | ResolutionStrategy::Full => {
+                                            | ResolutionStrategy::ParsimonyEm => {
                                                 let contrib = 1.0 / (k.len() as f32);
                                                 for g in k.iter() {
                                                     counts[*g as usize] += contrib;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -326,7 +326,6 @@ pub fn extract_counts(
                         //eprintln!("ambig count {} at {}!", *count, idx);
                         counts[idx] += *count as f32;
                     } else {
-                        /*
                         // report spliced if we can
                         match (is_spliced(*g1), is_spliced(*g2)) {
                             (true, false) => {
@@ -337,12 +336,10 @@ pub fn extract_counts(
                             }
                             _ => { /* do nothing */ }
                         }
-                        */
                     }
                 }
             }
             3..=10 => {
-                /*
                 // if we don't have *too* many distinct genes matching this UMI
                 // then apply the prefer-spliced rule.
 
@@ -372,7 +369,6 @@ pub fn extract_counts(
                         }
                     }
                 }
-                */
             }
             _ => {}
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -326,6 +326,7 @@ pub fn extract_counts(
                         //eprintln!("ambig count {} at {}!", *count, idx);
                         counts[idx] += *count as f32;
                     } else {
+                        /*
                         // report spliced if we can
                         match (is_spliced(*g1), is_spliced(*g2)) {
                             (true, false) => {
@@ -336,10 +337,12 @@ pub fn extract_counts(
                             }
                             _ => { /* do nothing */ }
                         }
+                        */
                     }
                 }
             }
             3..=10 => {
+                /*
                 // if we don't have *too* many distinct genes matching this UMI
                 // then apply the prefer-spliced rule.
 
@@ -369,6 +372,7 @@ pub fn extract_counts(
                         }
                     }
                 }
+                */
             }
             _ => {}
         }
@@ -528,7 +532,7 @@ pub fn extract_usa_eqmap(
                         // this is unspliced, so even if there is a next element
                         // it cannot belong to the same gene.
                         // modify the index so the contribution is
-                        // to the unspliced geen index.
+                        // to the unspliced gene index.
                         idx += unspliced_offset;
                     }
                     tvec.push(idx as u32);


### PR DESCRIPTION
Add support for `parsimony`, and `parsimony-em` in USA mode.  Added 2 new resolution methods `parsimony-gene`, and `parsimony-gene-em` mode (both work in USA mode or non-USA mode).  Changed default output to `mtx` format and added `--use-eds` flag.  Added (hidden) `--umi-edit-dist` flag for future use. Currently, it can force the parsimony modes to build PUGs only on identical UMIs.